### PR TITLE
Feat/productos crud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Entornos virtuales
+.env
+.venv/
+venv/
+env/
+
+# Cachés de Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+
+# IDE/Editor
+.vscode/
+.idea/
+
+# Sistema operativo
+.DS_Store
+Thumbs.db
+
+# Archivos locales de BD / pruebas
+lookmystyle.db
+*.sqlite
+*.sqlite3
+
+# Logs y herramientas
+*.log
+.pytest_cache/
+.mypy_cache/
+.coverage
+coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# LockMyStyle
-Proyecto de python para aplicaciones y servicios web
+# LookMyStyle API
+
+API REST con FastAPI y SQLAlchemy. Base de datos: SQL Server (conexión vía pyodbc). Configuración por `.env`.
+
+## Requisitos
+- Python 3.10+
+- SQL Server (local o remoto)
+- Microsoft ODBC Driver 17/18 for SQL Server
+- Dependencias de Python (ver `requirements.txt`)
+
+Instalación de dependencias:
+```bash
+py -m pip install -r requirements.txt

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,43 @@
+# app/database.py
+import os
+from urllib.parse import quote_plus
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, DeclarativeBase
+from dotenv import load_dotenv
+
+# Cargar variables desde .env (ubicado en la raíz del repo)
+load_dotenv()
+
+# Variables con valores por defecto seguros para local
+DRIVER = os.getenv("DB_DRIVER", "ODBC Driver 18 for SQL Server")
+SERVER = os.getenv("DB_SERVER", "localhost\\SQLEXPRESS")
+DBNAME = os.getenv("DB_NAME", "LookMyStyle")
+TRUSTED = os.getenv("DB_TRUSTED", "yes").lower()  # "yes" (Windows Auth) o "no" (SQL Auth)
+USER = os.getenv("DB_USER")
+PWD  = os.getenv("DB_PASSWORD")
+
+# Construir la cadena ODBC
+parts = [
+    f"Driver={{{DRIVER}}}",
+    f"Server={SERVER}",
+    f"Database={DBNAME}",
+    "TrustServerCertificate=yes",
+]
+
+if TRUSTED == "yes":
+    parts.append("Trusted_Connection=yes")
+else:
+    if not USER or not PWD:
+        raise RuntimeError("DB_TRUSTED=no pero faltan DB_USER y/o DB_PASSWORD")
+    parts.append(f"UID={USER}")
+    parts.append(f"PWD={PWD}")
+
+odbc_str = ";".join(parts) + ";"
+DATABASE_URL = "mssql+pyodbc:///?odbc_connect=" + quote_plus(odbc_str)
+
+# --- Estas tres deben quedar definidas a nivel de módulo ---
+engine = create_engine(DATABASE_URL, pool_pre_ping=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+class Base(DeclarativeBase):
+    pass

--- a/app/deps.py
+++ b/app/deps.py
@@ -1,0 +1,10 @@
+# app/deps.py
+from sqlalchemy.orm import Session
+from .database import SessionLocal
+
+def get_db() -> Session:
+    db: Session = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="LookMyStyle API", version="0.1.0")
+
+@app.get("/")
+def root():
+    return {"ok": True, "app": "LookMyStyle"}
+
+@app.get("/health")
+def health():
+    return {"status": "healthy"}

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,20 @@
-from fastapi import FastAPI
+# app/main.py
+from fastapi import FastAPI, HTTPException, status, Path, Query, Depends
+from typing import List, Optional
+from sqlalchemy.orm import Session
+from sqlalchemy import func
 
-app = FastAPI(title="LookMyStyle API", version="0.1.0")
+from .database import engine, Base
+from .deps import get_db
+from .models import ProductoORM
+from .schemas import ProductoIn, Producto
+
+app = FastAPI(title="LookMyStyle API", version="0.2.0")
+
+# Crear tablas al iniciar
+@app.on_event("startup")
+def on_startup():
+    Base.metadata.create_all(bind=engine)
 
 @app.get("/")
 def root():
@@ -9,3 +23,68 @@ def root():
 @app.get("/health")
 def health():
     return {"status": "healthy"}
+
+# -------- Productos (SQLAlchemy + SQL Server) --------
+
+@app.get("/productos", response_model=List[Producto], tags=["Productos"])
+def listar_productos(
+    categoria: Optional[str] = Query(None, description="Filtra por categoría"),
+    min_price: Optional[float] = Query(None, ge=0, description="Precio mínimo"),
+    max_price: Optional[float] = Query(None, ge=0, description="Precio máximo"),
+    db: Session = Depends(get_db),
+):
+    q = db.query(ProductoORM)
+    if categoria is not None:
+        q = q.filter(func.lower(ProductoORM.categoria) == func.lower(categoria.strip()))
+    if min_price is not None:
+        q = q.filter(ProductoORM.precio >= min_price)
+    if max_price is not None:
+        q = q.filter(ProductoORM.precio <= max_price)
+    return q.all()
+
+@app.get("/productos/{producto_id}", response_model=Producto, tags=["Productos"])
+def obtener_producto(
+    producto_id: int = Path(..., gt=0, description="ID (>0)"),
+    db: Session = Depends(get_db),
+):
+    prod = db.get(ProductoORM, producto_id)
+    if not prod:
+        raise HTTPException(status_code=404, detail="Producto no encontrado")
+    return prod
+
+@app.post("/productos", response_model=Producto, status_code=status.HTTP_201_CREATED, tags=["Productos"])
+def crear_producto(producto_in: ProductoIn, db: Session = Depends(get_db)):
+    prod = ProductoORM(**producto_in.model_dump())
+    db.add(prod)
+    db.commit()
+    db.refresh(prod)
+    return prod
+
+@app.put("/productos/{producto_id}", response_model=Producto, tags=["Productos"])
+def actualizar_producto(
+    producto_id: int = Path(..., gt=0, description="ID (>0)"),
+    producto_in: ProductoIn = ...,
+    db: Session = Depends(get_db),
+):
+    prod = db.get(ProductoORM, producto_id)
+    if not prod:
+        raise HTTPException(status_code=404, detail="Producto no encontrado")
+    data = producto_in.model_dump()
+    prod.nombre = data["nombre"]
+    prod.categoria = data["categoria"]
+    prod.precio = data["precio"]
+    prod.stock = data["stock"]
+    db.commit()
+    db.refresh(prod)
+    return prod
+
+@app.delete("/productos/{producto_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Productos"])
+def eliminar_producto(
+    producto_id: int = Path(..., gt=0, description="ID (>0)"),
+    db: Session = Depends(get_db),
+):
+    prod = db.get(ProductoORM, producto_id)
+    if not prod:
+        raise HTTPException(status_code=404, detail="Producto no encontrado")
+    db.delete(prod)
+    db.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,14 @@
+# app/models.py
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import String, Integer, Numeric
+from .database import Base
+
+class ProductoORM(Base):
+    __tablename__ = "productos"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    nombre: Mapped[str] = mapped_column(String(80), nullable=False)
+    categoria: Mapped[str] = mapped_column(String(40), nullable=False)
+    # Numeric(10,2) es mejor que Float para dinero
+    precio: Mapped[float] = mapped_column(Numeric(10, 2), nullable=False)
+    stock: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,19 @@
+# app/schemas.py
+from pydantic import BaseModel, Field, ConfigDict
+
+# Campos comunes (entrada/salida)
+class ProductoBase(BaseModel):
+    nombre: str = Field(..., min_length=1, max_length=80)
+    categoria: str = Field(..., min_length=1, max_length=40)
+    precio: float = Field(..., gt=0)       # > 0
+    stock: int = Field(default=0, ge=0)    # >= 0
+
+# Cuerpo de entrada (POST/PUT)
+class ProductoIn(ProductoBase):
+    pass
+
+# Respuesta/salida (incluye id)
+class Producto(ProductoBase):
+    id: int
+    # Permite serializar desde objetos ORM (SQLAlchemy)
+    model_config = ConfigDict(from_attributes=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.116.1
+uvicorn==0.35.0
+pydantic==2.11.7
+SQLAlchemy==2.0.34
+pyodbc==5.1.0
+python-dotenv==1.0.1


### PR DESCRIPTION
## Resumen
Migración de almacenamiento en memoria a **SQLAlchemy** con **SQL Server** para el recurso **Productos**.  
Se agregan filtros por categoría y rango de precios, validaciones y configuración por `.env`.

## Cambios principales
- Modelo ORM `ProductoORM` (SQLAlchemy).
- `database.py`: engine y sesión vía `pyodbc`, leyendo variables desde `.env`.
- `deps.py`: dependencia `get_db()` para inyectar `Session` por request.
- Endpoints de Productos usan `Session = Depends(get_db)`.
- `schemas.py`: salida con `model_config = ConfigDict(from_attributes=True)` para serializar objetos ORM.
- `main.py`: `create_all` en `startup` para crear tablas en entornos locales.
- Filtros en `/productos`: `categoria` (case-insensitive), `min_price`, `max_price`.
- Códigos HTTP coherentes: **201**, **200**, **204**, **404**, **422**.
- `.gitignore` actualizado para excluir `.env`, caches y artefactos.

## Cómo probar
1. Instalar dependencias:
   ```bash
   py -m pip install -r requirements.txt
